### PR TITLE
fix(mobile): prevent stale alarm intent from reopening ring screen

### DIFF
--- a/android/app/src/main/kotlin/dev/kashifkhan/drawbell/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/kashifkhan/drawbell/MainActivity.kt
@@ -232,5 +232,8 @@ class MainActivity : FlutterActivity() {
         val notificationManager =
             getSystemService(NotificationManager::class.java)
         notificationManager?.cancelAll()
+        intent.action = null
+        intent.removeExtra("alarm_payload")
+        intent.removeExtra("alarm_id")
     }
 }


### PR DESCRIPTION
## Summary
- Clear the consumed alarm launch intent after handling it in `MainActivity` so it is processed only once.
- Prevents app reopen from navigating back to the alarm ring screen after the user already dismissed the alarm.

Closes #2