### PR TITLE
feat(web): SEO improvements for Google Search visibility

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -3,11 +3,33 @@ import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
 
+const now = new Date().toISOString();
+
 export default defineConfig({
   site: 'https://drawbell.kashifkhan.dev',
   integrations: [
     tailwind({ applyBaseStyles: false }),
-    sitemap(),
+    sitemap({
+      changefreq: 'weekly',
+      priority: 0.7,
+      lastmod: new Date(),
+      customPages: [],
+      serialize(item) {
+        if (item.url === 'https://drawbell.kashifkhan.dev/') {
+          return { ...item, changefreq: 'daily', priority: 1.0, lastmod: now };
+        }
+        if (item.url === 'https://drawbell.kashifkhan.dev/blog/') {
+          return { ...item, changefreq: 'daily', priority: 0.9, lastmod: now };
+        }
+        if (item.url === 'https://drawbell.kashifkhan.dev/download/') {
+          return { ...item, changefreq: 'weekly', priority: 0.8, lastmod: now };
+        }
+        if (item.url.includes('/blog/')) {
+          return { ...item, changefreq: 'monthly', priority: 0.7 };
+        }
+        return item;
+      },
+    }),
     mdx(),
   ],
   output: 'static',

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/mdx": "^3.1.9",
+        "@astrojs/rss": "^4.0.17",
         "@astrojs/sitemap": "3.2.1",
         "@astrojs/tailwind": "^5.1.2",
         "@fontsource/dm-sans": "^5.2.8",
@@ -107,6 +108,26 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.17.tgz",
+      "integrity": "sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "5.4.1",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -3016,6 +3037,40 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
+      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.2"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5298,11 +5353,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6304,6 +6380,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^3.1.9",
+    "@astrojs/rss": "^4.0.17",
     "@astrojs/sitemap": "3.2.1",
     "@astrojs/tailwind": "^5.1.2",
     "@fontsource/dm-sans": "^5.2.8",

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -61,6 +61,9 @@ const webSiteSchema = {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#D94A09" />
 
+  <!-- Google Search Console verification -->
+  <meta name="google-site-verification" content="GsnVvhnHNdZC3YMYInZxanh97DATIV3-Ooup2YHYcS8" />
+
   <!-- Primary SEO -->
   <title>{fullTitle}</title>
   <meta name="description" content={description} />
@@ -100,6 +103,7 @@ const webSiteSchema = {
   <!-- Favicon -->
   <link rel="icon"             type="image/png" href="/favicon.png" />
   <link rel="apple-touch-icon" href="/favicon.png" />
+  <link rel="alternate" type="application/rss+xml" title="DrawBell Blog" href="/rss.xml" />
 
   <!-- JSON-LD: Organization + WebSite -->
   <script type="application/ld+json" set:html={JSON.stringify(orgSchema)} />

--- a/web/src/pages/blog/[slug].astro
+++ b/web/src/pages/blog/[slug].astro
@@ -30,12 +30,14 @@ const formattedDate = publishedDate.toLocaleDateString('en-US', {
 });
 const isoDate = publishedDate.toISOString();
 
+const postUrl = new URL(`/blog/${post.slug}`, Astro.site).toString();
+
 const blogPostSchema = {
   '@context': 'https://schema.org',
   '@type': 'BlogPosting',
   headline: title,
   description,
-  url: new URL(`/blog/${post.slug}`, Astro.site).toString(),
+  url: postUrl,
   datePublished: isoDate,
   dateModified: updatedDate?.toISOString() ?? isoDate,
   author: {
@@ -52,18 +54,46 @@ const blogPostSchema = {
     : 'https://drawbell.kashifkhan.dev/og-image.svg',
   keywords: tags.join(', '),
   inLanguage: 'en-US',
+  mainEntityOfPage: { '@type': 'WebPage', '@id': postUrl },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: 'https://drawbell.kashifkhan.dev/',
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Blog',
+      item: 'https://drawbell.kashifkhan.dev/blog/',
+    },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: title,
+      item: postUrl,
+    },
+  ],
 };
 ---
 
 <BaseLayout
   {title}
   {description}
+  image={image ?? undefined}
   type="article"
   publishedDate={isoDate}
   {author}
   {tags}
 >
   <script type="application/ld+json" set:html={JSON.stringify(blogPostSchema)} slot="head" />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} slot="head" />
 
   <Header />
 

--- a/web/src/pages/rss.xml.ts
+++ b/web/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+    (a, b) => b.data.publishedDate.valueOf() - a.data.publishedDate.valueOf(),
+  );
+
+  return rss({
+    title: 'DrawBell Blog',
+    description:
+      'Sleep science, habit research, and morning strategies — with a drawing alarm that actually wakes you up.',
+    site: context.site!.toString(),
+    items: posts.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.publishedDate,
+      description: post.data.description,
+      link: `/blog/${post.slug}/`,
+      categories: post.data.tags,
+      author: post.data.author,
+    })),
+    customData: `<language>en-us</language>`,
+  });
+}


### PR DESCRIPTION
## Summary

- Add RSS feed at `/rss.xml` with all 21 blog posts via `@astrojs/rss`
- Add `<link rel="alternate">` RSS discovery tag to every page `<head>`
- Add sitemap `priority`, `changefreq`, and `lastmod` per route type (homepage=daily/1.0, blog index=daily/0.9, posts=monthly/0.7)
- Add `BreadcrumbList` JSON-LD to every blog post page for Google breadcrumb display in search results
- Add `mainEntityOfPage` to `BlogPosting` schema
- Pass per-post hero image as `og:image` so each blog share card uses the correct image
- Add Google Search Console ownership verification meta tag