### PR TITLE
docs: improve AGENTS.md with accurate, complete agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,14 @@
 
 ## Project Overview
 
-DrawBell is a Flutter alarm app that requires users to draw a specific doodle (verified by on-device AI) to dismiss the alarm. The AI model is a TFLite SE-ResNet trained on Google Quick Draw (345 categories, 76% top-1 accuracy). Android-first. Package ID: `dev.kashifkhan.drawbell`.
+DrawBell is a Flutter alarm app that requires users to draw a specific doodle
+(verified by on-device AI) to dismiss the alarm. The AI model is a TFLite
+SE-ResNet trained on Google Quick Draw (345 categories, 76% top-1 accuracy).
+Android-first. Package ID: `dev.kashifkhan.drawbell`.
+
+- Flutter **3.32.8** / Dart **3.8.1**
+- No code generation (no Freezed, no json_serializable, no Isar)
+- Manual `toJson` / `fromJson` everywhere
 
 ## Build Commands
 
@@ -10,45 +17,112 @@ DrawBell is a Flutter alarm app that requires users to draw a specific doodle (v
 # Get dependencies
 flutter pub get
 
+# Add a new dependency (never edit pubspec.yaml manually)
+flutter pub add <package_name>
+
 # Run the app (debug)
 flutter run
 
-# Build APK
+# Build APK (all ABIs)
 flutter build apk
+
+# Build split APKs per ABI (release)
+flutter build apk --split-per-abi
 
 # Build app bundle
 flutter build appbundle
 
-# Analyze (lint)
-flutter analyze
+# Analyze (lint) -- must pass with zero warnings before commit
+flutter analyze --fatal-infos
 
 # Format code
 dart format lib/ test/
 
-# Format check (CI)
+# Format check (CI -- exits non-zero if any file would change)
 dart format --set-exit-if-changed lib/ test/
 
 # Run all tests
 flutter test
 
 # Run a single test file
-flutter test test/path/to/test_file.dart
+flutter test test/widget_test.dart
 
-# Run a single test by name
-flutter test --name "test description" test/path/to/test_file.dart
+# Run a single test by name (substring match)
+flutter test --name "AlarmModel round-trip JSON serialisation" test/widget_test.dart
 
 # Run tests with coverage
 flutter test --coverage
 ```
+
+## Pre-commit Checklist
+
+Run these in order and fix all issues before committing:
+
+```bash
+dart format lib/ test/
+flutter analyze --fatal-infos
+flutter test
+```
+
+## Architecture
+
+```
+lib/
+  main.dart            # app entry, provider overrides, notification cold-start
+  theme.dart           # AppTheme.light() / AppTheme.dark(), brand color
+  router.dart          # GoRouter, StatefulShellRoute for 4 nav-bar tabs
+  core/
+    constants.dart     # Difficulty/HintMode/AlarmSound enums, top-level consts
+    utils.dart         # pure formatting helpers (formatTimeOfDay, formatDays…)
+  models/              # plain immutable Dart classes, toJson/fromJson, copyWith
+    alarm_model.dart
+    drawing_result.dart
+    dismissal_record.dart
+  providers/           # Riverpod StateNotifierProviders and plain Providers
+    alarm_provider.dart
+    settings_provider.dart
+  services/            # all business logic; no Flutter imports
+    alarm_service.dart
+    audio_service.dart
+    classifier_service.dart
+    hint_service.dart
+    imported_sound_service.dart
+    native_alarm_service.dart
+    notification_service.dart
+    ringtone_service.dart
+    storage_service.dart
+  screens/
+    app_shell.dart
+    home/            home_screen.dart + widgets/
+    alarm_editor/    alarm_editor_screen.dart + widgets/
+    alarm_ring/      alarm_ring_screen.dart + widgets/
+    practice/        practice_screen.dart + widgets/
+    stats/           stats_screen.dart + widgets/
+    settings/        settings_screen.dart
+    onboarding/      onboarding_screen.dart
+    info/            about / contact / privacy / terms screens
+android/
+  app/src/main/kotlin/dev/kashifkhan/drawbell/
+    MainActivity.kt
+    AlarmReceiver.kt           # BroadcastReceiver for exact alarm firing
+    AlarmPlaybackService.kt    # foreground service keeps audio alive
+    NativeAlarmScheduler.kt    # wraps AlarmManager exact alarms
+    NativeAlarmStore.kt        # native-side persistence for boot rescheduling
+```
+
+Key decisions:
+- **Storage**: SharedPreferences only (JSON blobs); alarms under key `'alarms'`, stats under `'dismissal_stats'`, settings as individual typed keys.
+- **Alarm scheduling**: Custom Kotlin `NativeAlarmScheduler` + `AlarmManager`, not a Flutter plugin.
+- **Navigation**: `StatefulShellRoute.indexedStack` for 4 bottom-nav tabs; full-screen modal routes for editor/ring/onboarding.
+- **TFLite**: Float16 model, 28×28 pixel input rendered via `ui.PictureRecorder` in `classifier_service.dart`.
 
 ## Code Style Rules
 
 ### Formatting
 
 - Line length: 80 characters (Dart default)
-- Use `dart format` before every commit
-- Trailing commas on all argument lists (widgets, functions) for consistent formatting
-- No manual line breaks inside formatted code -- let `dart format` handle it
+- `dart format` manages all line breaks -- never add manual breaks in formatted code
+- Trailing commas on every argument list and parameter list so `dart format` produces stable multi-line output
 
 ### Comments
 
@@ -58,9 +132,9 @@ flutter test --coverage
 
 ### Imports
 
-- Dart SDK imports first, then package imports, then relative imports
-- One blank line between each import group
-- Always use relative imports for project files (`import '../models/alarm_model.dart'`)
+- Group order: Dart SDK → Flutter SDK → third-party packages → relative project files
+- One blank line between each group
+- Always use relative imports for project files: `import '../models/alarm_model.dart'`
 - Never use `package:drawbell/` for internal imports
 - Remove all unused imports
 
@@ -68,113 +142,112 @@ flutter test --coverage
 
 - Files: `snake_case.dart` (e.g. `alarm_model.dart`, `home_screen.dart`)
 - Classes: `PascalCase` (e.g. `AlarmModel`, `HomeScreen`)
-- Variables/functions: `camelCase` (e.g. `alarmList`, `formatTime`)
+- Variables / functions: `camelCase` (e.g. `alarmList`, `formatTime`)
 - Constants: `camelCase` (e.g. `defaultDifficulty`, `maxAttempts`)
 - Private members: prefix with `_` (e.g. `_counter`, `_onTap`)
 - Enums: `PascalCase` name, `camelCase` values (e.g. `Difficulty.easy`)
-- Providers (Riverpod): `camelCase` ending with `Provider` (e.g. `alarmListProvider`)
+- Riverpod providers: `camelCase` ending with `Provider` (e.g. `alarmListProvider`)
 
 ### Types
 
 - Always specify types explicitly -- no `var`, no `dynamic` unless unavoidable
 - Use `final` for all local variables that are not reassigned
 - Use `const` constructors wherever possible
-- Prefer `List<Widget>` over `<Widget>[]` in type annotations
 - Use `required` for all named parameters that must be provided
 
 ### Error Handling
 
-- Never silently swallow errors -- always log or handle
+- Never silently swallow errors -- always log or rethrow
 - Use specific exception types, not generic `Exception`
-- Services should return result types or throw typed exceptions
-- UI should show user-facing error messages via SnackBar
+- Services throw typed exceptions or return typed result objects
+- UI shows user-facing errors via `ScaffoldMessenger.of(context).showSnackBar`
 
-### Architecture
+### Models
 
-- State management: Riverpod (flutter_riverpod)
-- Navigation: GoRouter (go_router)
-- Storage: SharedPreferences for settings, Isar for structured data
-- All business logic lives in `lib/services/`
-- All data classes live in `lib/models/`
-- All constants and helpers live in `lib/core/`
-- Screens live in `lib/screens/<feature>/` with a `widgets/` subfolder
+- Plain immutable Dart classes only -- no codegen, no Freezed
+- All fields `final` with explicit types
+- Provide `copyWith`, `toJson`, `fromJson` on every model
+- Use safe casting in `fromJson` (`as int`, `?? defaultValue`); never assume type
+
+### Services
+
+- No Flutter imports in `lib/services/`; services are pure Dart
+- Provide explicit `load()` / `dispose()` lifecycle where needed
+- Guard with `isLoaded` / `isInitialized` before use
+- `StorageService` must be `await init()` before any other service
+
+### Providers (Riverpod)
+
+- Use `StateNotifierProvider` for mutable lists / complex state
+- Use `Provider` for plain singletons (e.g. `storageServiceProvider`)
+- Override `storageServiceProvider` in `main()` with the pre-initialised instance
+- Every mutating notifier method: persist → update state → reschedule if needed
 
 ### Widget / Component Rules
 
+- Prefer `ConsumerWidget` over `StatefulWidget`; only use `ConsumerStatefulWidget` when lifecycle methods are required
 - Every widget must be small and single-purpose
-- Extract reusable widgets into the screen's `widgets/` subfolder
-- DRY -- never duplicate widget trees, extract shared components
-- Stateless over Stateful -- use `ConsumerWidget` (Riverpod) when state is needed
+- Extract reusable widgets to the screen's `widgets/` subfolder
+- Never duplicate widget trees -- extract shared components
 - All widget constructors must be `const` when possible
-- No inline styles -- use `Theme.of(context)` for colors, text styles, shapes
-- No magic numbers -- extract to constants
+- No inline styles -- use `Theme.of(context).colorScheme` and `Theme.of(context).textTheme`
+- No magic numbers -- extract to `lib/core/constants.dart`
 
 ### UI/UX Consistency
 
-- Theme color: `#d94a09` as Material 3 seed color
-- Use `ColorScheme.fromSeed(seedColor: Color(0xFFD94A09))` for both light and dark
-- Always use theme colors from `Theme.of(context).colorScheme`
-- Never hardcode colors in widgets (except canvas: white bg, black stroke)
-- Shapes: 12-16dp border radius consistently
-- Spacing: use multiples of 4 (4, 8, 12, 16, 24, 32)
-- All interactive elements must have proper touch targets (min 48x48)
-- Follow Material 3 design guidelines throughout
-- Support both light and dark mode
+- Brand color: `Color(0xFFD94A09)` (defined as `AppTheme.brandOrange`)
+- Light theme: `ColorScheme.fromSeed(seedColor: AppTheme.brandOrange)`
+- Dark theme: hand-crafted warm `ColorScheme` (surface `#1A1210`, container `#2A1F1A`)
+- Always read colors from `Theme.of(context).colorScheme` in widgets
+- Exception: drawing canvas uses white background, black stroke (hardcoded by design)
+- Border radius: 12–16 dp consistently
+- Spacing: multiples of 4 (4, 8, 12, 16, 24, 32)
+- Minimum touch target: 48×48 dp
+- Material 3 throughout; support both light and dark mode
 
-### Project Structure
+### Analyzer
 
-```
-lib/
-  main.dart
-  theme.dart
-  router.dart
-  core/
-    constants.dart
-    utils.dart
-  models/
-    alarm_model.dart
-    drawing_result.dart
-  services/
-    classifier_service.dart
-    alarm_service.dart
-    notification_service.dart
-    audio_service.dart
-    storage_service.dart
-  screens/
-    home/
-      home_screen.dart
-      widgets/
-    alarm_editor/
-      alarm_editor_screen.dart
-    alarm_ring/
-      alarm_ring_screen.dart
-      widgets/
-    settings/
-      settings_screen.dart
+`analysis_options.yaml` enables strict mode -- all three flags are on:
+
+```yaml
+strict-casts: true
+strict-inference: true
+strict-raw-types: true
 ```
 
-### Testing
+`missing_required_param`, `missing_return`, and `dead_code` are treated as
+errors. `flutter analyze --fatal-infos` must exit 0 before any commit.
 
-- Test files mirror `lib/` structure inside `test/`
-- File naming: `<source_file>_test.dart`
-- Group related tests with `group()`
-- Use descriptive test names that state expected behavior
-- Widget tests use `pumpWidget` with required providers wrapped
+## Testing
 
-### Git
+- Test files mirror `lib/` structure inside `test/` with suffix `_test.dart`
+- Group related tests with `group('ClassName', () { ... })`
+- Test names state expected behaviour: `'round-trip JSON serialisation'`
+- Widget tests wrap with `ProviderScope` and a minimal `GoRouter`:
 
-- Run `flutter analyze` and `dart format lib/ test/` before every commit
-- Fix all analyzer warnings before committing
-- Commit messages: `type: short description` (e.g. `feat: add home screen with alarm list`)
-- Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `style`
+```dart
+final GoRouter testRouter = GoRouter(
+  initialLocation: '/',
+  routes: [GoRoute(path: '/', builder: (_, __) => const HomeScreen())],
+);
+await tester.pumpWidget(
+  ProviderScope(child: MaterialApp.router(routerConfig: testRouter)),
+);
+await tester.pumpAndSettle();
+```
 
-### Dependencies (planned)
+## Git Workflow
 
-- when every you need to add new dependency add by using cli `flutter pub add <dependencies>`
+- `main` is a protected branch -- never push directly
+- Branch naming: `feat/<slug>`, `fix/<slug>`, `docs/<slug>`, `refactor/<slug>`
+- Always open a PR against `main`; link the relevant GitHub issue in the PR body (`Closes #<n>`)
+- Commit messages: `type: short description`
+  - Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `style`
+  - Example: `feat: add home screen with alarm list`
 
-### Reference
+## Reference Paths
 
-- AI model: `/home/zarqan-khn/mycoding/ai-ml-dl/kaggle/quickdraw-345-classifier/model/`
+- TFLite model: `/home/zarqan-khn/mycoding/ai-ml-dl/kaggle/quickdraw-345-classifier/model/`
 - Reference Flutter app: `/home/zarqan-khn/mycoding/ai-ml-dl/kaggle/quickdraw-345-classifier/quickdraw_app/`
 - Plan: `docs/DRAWBELL_PLAN.md`
 - Proposal: `docs/DRAWBELL_PROPOSAL.md`


### PR DESCRIPTION
## Summary

- Fix inaccuracies in the existing `AGENTS.md` that could mislead agentic coding agents
- Expand architecture, testing, and git workflow sections with accurate details from the actual codebase
- Clarify the dependency install rule: always `flutter pub add`, never edit `pubspec.yaml` manually

## Changes

- Corrected storage layer reference (SharedPreferences only, not Isar)
- Added `--fatal-infos` flag to analyze command (matches CI)
- Added `flutter build apk --split-per-abi` command
- Added explicit pre-commit checklist section
- Expanded architecture section with all current services, screens, and key architectural decisions
- Added full widget test boilerplate (`ProviderScope` + `GoRouter`) to testing section
- Expanded git workflow with branch naming conventions and PR/issue linking rule
- Added dependency install rule prominently in build commands

Closes #7