### PR TITLE
fix(snooze): preserve original alarm categories, sound and label on snooze

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,6 +58,7 @@ void _handleNotificationPayload(String payload) {
         ? List<String>.from(data['categories'] as List)
         : const [];
     final String sound = data['sound'] as String? ?? 'default';
+    final String label = data['label'] as String? ?? '';
     final String? alarmId = data['alarmId'] as String?;
     _router.push(
       '/alarm/ring',
@@ -65,6 +66,7 @@ void _handleNotificationPayload(String payload) {
         'difficulty': difficulty,
         'categories': categories,
         'sound': sound,
+        'label': label,
         'usesNativeAlarmAudio': true,
         if (alarmId != null) 'alarmId': alarmId,
       },

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -56,6 +56,7 @@ GoRouter buildRouter({String initialLocation = '/'}) {
           final List<String> categories =
               extras['categories'] as List<String>? ?? const [];
           final String sound = extras['sound'] as String? ?? 'default';
+          final String label = extras['label'] as String? ?? '';
           final bool usesNativeAlarmAudio =
               extras['usesNativeAlarmAudio'] as bool? ?? false;
           final bool isTestMode = extras['isTestMode'] as bool? ?? false;
@@ -64,6 +65,7 @@ GoRouter buildRouter({String initialLocation = '/'}) {
             difficulty: difficulty,
             categories: categories,
             sound: sound,
+            label: label,
             usesNativeAlarmAudio: usesNativeAlarmAudio,
             isTestMode: isTestMode,
             alarmId: alarmId,

--- a/lib/screens/alarm_ring/alarm_ring_screen.dart
+++ b/lib/screens/alarm_ring/alarm_ring_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -29,6 +30,7 @@ class AlarmRingScreen extends ConsumerStatefulWidget {
   final Difficulty difficulty;
   final List<String> categories;
   final String sound;
+  final String label;
   final bool usesNativeAlarmAudio;
   final bool isTestMode;
   final String? alarmId;
@@ -38,6 +40,7 @@ class AlarmRingScreen extends ConsumerStatefulWidget {
     required this.difficulty,
     this.categories = const [],
     this.sound = 'default',
+    this.label = '',
     this.usesNativeAlarmAudio = false,
     this.isTestMode = false,
     this.alarmId,
@@ -308,11 +311,17 @@ class _AlarmRingScreenState extends ConsumerState<AlarmRingScreen> {
     final DateTime snoozeTime = DateTime.now().add(
       Duration(minutes: snoozeMinutes),
     );
-    final String payload = '{"difficulty":${widget.difficulty.index}}';
+    final String payload = jsonEncode({
+      'difficulty': widget.difficulty.index,
+      'categories': widget.categories,
+      'sound': widget.sound,
+      'label': widget.label,
+    });
+    final String title = widget.label.isNotEmpty ? widget.label : 'DrawBell';
 
     await NotificationService().scheduleAlarm(
       id: snoozeTime.hashCode & 0x7FFFFFFF,
-      title: 'DrawBell',
+      title: title,
       body: 'Snoozed alarm — draw to dismiss!',
       scheduledTime: snoozeTime,
       payload: payload,

--- a/lib/screens/alarm_ring/alarm_ring_screen.dart
+++ b/lib/screens/alarm_ring/alarm_ring_screen.dart
@@ -311,12 +311,14 @@ class _AlarmRingScreenState extends ConsumerState<AlarmRingScreen> {
     final DateTime snoozeTime = DateTime.now().add(
       Duration(minutes: snoozeMinutes),
     );
-    final String payload = jsonEncode({
+    final Map<String, Object> payloadData = <String, Object>{
       'difficulty': widget.difficulty.index,
       'categories': widget.categories,
       'sound': widget.sound,
       'label': widget.label,
-    });
+      if (widget.alarmId != null) 'alarmId': widget.alarmId!,
+    };
+    final String payload = jsonEncode(payloadData);
     final String title = widget.label.isNotEmpty ? widget.label : 'DrawBell';
 
     await NotificationService().scheduleAlarm(

--- a/lib/services/alarm_service.dart
+++ b/lib/services/alarm_service.dart
@@ -25,6 +25,7 @@ class AlarmService {
       'difficulty': alarm.difficulty.index,
       'categories': alarm.categories,
       'sound': alarm.sound,
+      'label': alarm.label,
     });
 
     final String title = alarm.label.isNotEmpty ? alarm.label : 'DrawBell';


### PR DESCRIPTION
## Summary

- Forward `categories`, `sound`, and `label` from the original alarm into the snooze notification payload in `_snooze()` (`alarm_ring_screen.dart`)
- Add `label` field to `AlarmRingScreen` so the snooze notification title reflects the original alarm label
- Decode `label` from notification payload in `_handleNotificationPayload` (`main.dart`) and forward it to `AlarmRingScreen` via the router extras
- Include `label` in the scheduled alarm payload in `AlarmService.scheduleAlarm` so it is available end-to-end

Closes #11

## Acceptance Criteria Verification

- [x] Snoozed alarm fires with the same `categories` as the original
- [x] Snoozed alarm fires with the same `sound` as the original
- [x] Snoozed alarm fires with the same `label` as the original
- [x] No regression on the standard (non-snooze) alarm flow — all 30 tests pass, `flutter analyze --fatal-infos` exits 0