### PR TITLE
fix(onboarding): use storageServiceProvider instead of raw StorageService

### DIFF
--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../services/storage_service.dart';
+import '../../providers/alarm_provider.dart';
 
-class OnboardingScreen extends StatefulWidget {
+class OnboardingScreen extends ConsumerStatefulWidget {
   const OnboardingScreen({super.key});
 
   @override
-  State<OnboardingScreen> createState() => _OnboardingScreenState();
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
 }
 
-class _OnboardingScreenState extends State<OnboardingScreen> {
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   final PageController _controller = PageController();
   int _currentPage = 0;
 
@@ -30,9 +31,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         curve: Curves.easeInOut,
       );
     } else {
-      final StorageService storage = StorageService();
-      await storage.init();
-      await storage.setOnboardingComplete();
+      await ref.read(storageServiceProvider).setOnboardingComplete();
       if (mounted) context.go('/');
     }
   }


### PR DESCRIPTION
## Summary

- Converts `OnboardingScreen` from `StatefulWidget` to `ConsumerStatefulWidget`
- Replaces the raw `StorageService()` instantiation and manual `init()` call with `ref.read(storageServiceProvider)`, consistent with every other screen in the app
- Removes the now-unused `storage_service.dart` import and adds `alarm_provider.dart`

## Root Cause

`_OnboardingScreenState._next()` was constructing a second `StorageService` instance and calling `init()` on it independently, which could race or diverge from the singleton managed by Riverpod.

## Testing

- `flutter analyze --fatal-infos` — zero issues
- `flutter test` — all 30 tests pass
- `dart format` — no changes needed

Closes #13