### PR TITLE
refactor(classifier): load ClassifierService once at startup as a shared singleton

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'core/constants.dart';
 import 'providers/alarm_provider.dart';
 import 'providers/settings_provider.dart';
 import 'router.dart';
+import 'services/classifier_service.dart';
 import 'services/notification_service.dart';
 import 'services/storage_service.dart';
 import 'theme.dart';
@@ -20,6 +21,9 @@ Future<void> main() async {
 
   final StorageService storage = StorageService();
   await storage.init();
+
+  final ClassifierService classifier = ClassifierService();
+  await classifier.load();
 
   final String initialRoute = storage.isOnboardingComplete
       ? '/'
@@ -41,7 +45,10 @@ Future<void> main() async {
 
   runApp(
     ProviderScope(
-      overrides: [storageServiceProvider.overrideWithValue(storage)],
+      overrides: [
+        storageServiceProvider.overrideWithValue(storage),
+        classifierServiceProvider.overrideWithValue(classifier),
+      ],
       child: const DrawBellApp(),
     ),
   );

--- a/lib/providers/alarm_provider.dart
+++ b/lib/providers/alarm_provider.dart
@@ -3,11 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/alarm_model.dart';
 import '../models/dismissal_record.dart';
 import '../services/alarm_service.dart';
+import '../services/classifier_service.dart';
 import '../services/storage_service.dart';
 
 final Provider<StorageService> storageServiceProvider =
     Provider<StorageService>((Ref ref) {
       return StorageService();
+    });
+
+final Provider<ClassifierService> classifierServiceProvider =
+    Provider<ClassifierService>((Ref ref) {
+      return ClassifierService();
     });
 
 final StateNotifierProvider<AlarmListNotifier, List<AlarmModel>>

--- a/lib/screens/alarm_ring/alarm_ring_screen.dart
+++ b/lib/screens/alarm_ring/alarm_ring_screen.dart
@@ -48,7 +48,7 @@ class AlarmRingScreen extends ConsumerStatefulWidget {
 }
 
 class _AlarmRingScreenState extends ConsumerState<AlarmRingScreen> {
-  final ClassifierService _classifier = ClassifierService();
+  late final ClassifierService _classifier;
   final AudioService _audio = AudioService();
 
   final List<List<Offset>> _strokes = [];
@@ -74,6 +74,7 @@ class _AlarmRingScreenState extends ConsumerState<AlarmRingScreen> {
   @override
   void initState() {
     super.initState();
+    _classifier = ref.read(classifierServiceProvider);
     _currentThreshold = widget.difficulty.threshold;
     _startTime = DateTime.now();
     _initAlarm();
@@ -81,7 +82,6 @@ class _AlarmRingScreenState extends ConsumerState<AlarmRingScreen> {
 
   Future<void> _initAlarm() async {
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
-    await _classifier.load();
     _pickPrompt();
     setState(() => _isLoading = false);
     if (!widget.isTestMode && !widget.usesNativeAlarmAudio) {
@@ -335,7 +335,6 @@ class _AlarmRingScreenState extends ConsumerState<AlarmRingScreen> {
   void dispose() {
     _idleTimer?.cancel();
     _audio.dispose();
-    _classifier.dispose();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     super.dispose();
   }

--- a/lib/screens/practice/practice_screen.dart
+++ b/lib/screens/practice/practice_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/constants.dart';
 import '../../models/drawing_result.dart';
+import '../../providers/alarm_provider.dart';
 import '../../services/classifier_service.dart';
 import '../../services/hint_service.dart';
 import '../../theme.dart';
@@ -13,21 +15,20 @@ import 'widgets/category_picker_sheet.dart';
 import 'widgets/practice_result_overlay.dart';
 import 'widgets/prediction_tile.dart';
 
-class PracticeScreen extends StatefulWidget {
+class PracticeScreen extends ConsumerStatefulWidget {
   const PracticeScreen({super.key});
 
   @override
-  State<PracticeScreen> createState() => _PracticeScreenState();
+  ConsumerState<PracticeScreen> createState() => _PracticeScreenState();
 }
 
-class _PracticeScreenState extends State<PracticeScreen> {
-  final ClassifierService _classifier = ClassifierService();
+class _PracticeScreenState extends ConsumerState<PracticeScreen> {
+  late final ClassifierService _classifier;
 
   final List<List<Offset>> _strokes = [];
   List<Offset> _currentStroke = [];
   List<DrawingResult> _predictions = [];
 
-  bool _isLoading = true;
   bool _isClassifying = false;
 
   String? _targetCategory;
@@ -45,12 +46,7 @@ class _PracticeScreenState extends State<PracticeScreen> {
   @override
   void initState() {
     super.initState();
-    _initClassifier();
-  }
-
-  Future<void> _initClassifier() async {
-    await _classifier.load();
-    if (mounted) setState(() => _isLoading = false);
+    _classifier = ref.read(classifierServiceProvider);
   }
 
   Future<void> _classify() async {
@@ -252,7 +248,6 @@ class _PracticeScreenState extends State<PracticeScreen> {
 
   @override
   void dispose() {
-    _classifier.dispose();
     super.dispose();
   }
 
@@ -260,27 +255,6 @@ class _PracticeScreenState extends State<PracticeScreen> {
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
     final TextTheme textTheme = Theme.of(context).textTheme;
-
-    if (_isLoading) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Practice')),
-        body: Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const CircularProgressIndicator(),
-              const SizedBox(height: 16),
-              Text(
-                'Loading AI model...',
-                style: textTheme.bodyMedium?.copyWith(
-                  color: colors.onSurfaceVariant,
-                ),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary

- Adds `classifierServiceProvider` (`Provider<ClassifierService>`) to `lib/providers/alarm_provider.dart`, mirroring the existing `storageServiceProvider` pattern.
- Calls `await classifier.load()` once in `main()` before `runApp`, then passes the pre-loaded instance via `ProviderScope` overrides.
- Refactors `AlarmRingScreen` to read the classifier from `classifierServiceProvider` instead of constructing and loading it locally on every screen open.
- Refactors `PracticeScreen` from `StatefulWidget` to `ConsumerStatefulWidget` so it can read the same shared instance; removes the per-screen `load()` call and the now-redundant loading state.

## Acceptance Criteria

- [x] `ClassifierService.load()` is called exactly once during app startup
- [x] Both `AlarmRingScreen` and `PracticeScreen` share the same loaded interpreter instance
- [x] No perceptible delay when opening either screen after the initial app load
- [x] `flutter analyze --fatal-infos` passes with zero warnings

Closes #12